### PR TITLE
BUG fix for auditd service https://bugzilla.redhat.com/show_bug.cgi?id=1026648.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -22,10 +22,13 @@
       name: ntpd
       state: restarted
 
+# Handler changed to upstream due to known bug with auditd restarts
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1026648.
 - name: restart auditd
   service:
       name: auditd
       state: restarted
+      use: upstart
       
 - name: restart xinetd
   service:


### PR DESCRIPTION
This is a bug fix for RHEL 7 and auditd (and likely other service daemons) which require specific shell extensions that systemctl does not provide.

Changing 'use: upstart is the fix until RHEL7 patches the service appropriately.